### PR TITLE
Support for multiplicative effects for arbitrary covariates in the spatial data

### DIFF
--- a/cell2location/models/_cell2location_model.py
+++ b/cell2location/models/_cell2location_model.py
@@ -74,6 +74,11 @@ class Cell2location(QuantileMixin, PyroSampleMixin, PyroSviTrainMixin, PltExport
         self.cell_state_df_ = cell_state_df
         self.n_factors_ = cell_state_df.shape[1]
         self.factor_names_ = cell_state_df.columns.values
+        # annotations for extra categorical covariates
+        if "extra_categoricals" in self.adata.uns["_scvi"].keys():
+            self.extra_categoricals_ = self.adata.uns["_scvi"]["extra_categoricals"]
+            self.n_extra_categoricals_ = self.adata.uns["_scvi"]["extra_categoricals"]["n_cats_per_key"]
+            model_kwargs["n_extra_categoricals"] = self.n_extra_categoricals_
 
         if not detection_mean_per_sample:
             # compute expected change in sensitivity (m_g in V1 or y_s in V2)

--- a/cell2location/models/_cell2location_module.py
+++ b/cell2location/models/_cell2location_module.py
@@ -28,13 +28,14 @@ class LocationModelLinearDependentWMultiExperimentLocationBackgroundNormLevelGen
     as a linear function of expression signatures of reference cell types :math:`g_{f,g}`:
 
     .. math::
-        \mu_{s,g} = (m_{g} \left (\sum_{f} {w_{s,f} \: g_{f,g}} \right) + s_{e,g}) y_{s}
+        \mu_{s,g} = (m_{g} \left (\sum_{f} {w_{s,f} \: g_{f,g}} \right) + s_{e,g}) y_{s} y_{t,g}
 
     Here, :math:`w_{s,f}` denotes regression weight of each reference signature :math:`f` at location :math:`s`, which can be interpreted as the expected number of cells at location :math:`s` that express reference signature :math:`f`;
     :math:`g_{f,g}` denotes the reference signatures of cell types :math:`f` of each gene :math:`g`, `cell_state_df` input ;
     :math:`m_{g}` denotes a gene-specific scaling parameter which adjusts for global differences in sensitivity between technologies (platform effect);
     :math:`y_{s}` denotes a location/observation-specific scaling parameter which adjusts for differences in sensitivity between observations and batches;
     :math:`s_{e,g}` is additive component that account for gene- and location-specific shift, such as due to contaminating or free-floating RNA.
+    :math:`y_{t,g}` denotes per gene :math:`g` multiplicative detection efficiency normalisation for each covariate :math:`t`
 
     To account for the similarity of location patterns across cell types, :math:`w_{s,f}` is modelled using
     another layer  of decomposition (factorization) using :math:`r={1, .., R}` groups of cell types,

--- a/cell2location/models/_cell2location_module.py
+++ b/cell2location/models/_cell2location_module.py
@@ -228,7 +228,7 @@ class LocationModelLinearDependentWMultiExperimentLocationBackgroundNormLevelGen
         else:
             return self._get_fn_args_from_batch_no_cat
 
-    def create_plates(self, x_data, idx, batch_index):
+    def create_plates(self, x_data, idx, batch_index, extra_categoricals):
         return pyro.plate("obs_plate", size=self.n_obs, dim=-2, subsample=idx)
 
     def list_obs_plate_vars(self):
@@ -273,7 +273,7 @@ class LocationModelLinearDependentWMultiExperimentLocationBackgroundNormLevelGen
                 dim=1,
             )
 
-        obs_plate = self.create_plates(x_data, idx, batch_index)
+        obs_plate = self.create_plates(x_data, idx, batch_index, extra_categoricals)
 
         # =====================Gene expression level scaling m_g======================= #
         # Explains difference in sensitivity for each gene between single cell and spatial technology

--- a/tests/test_cell2location.py
+++ b/tests/test_cell2location.py
@@ -120,3 +120,20 @@ def test_cell2location():
     # export the estimated cell abundance (summary of the posterior distribution)
     # full data
     st_model.export_posterior(dataset, sample_kwargs={"num_samples": 10, "batch_size": st_model.adata.n_obs})
+
+    ##  Model with extra categorical covariates  ##
+    dataset_sp = dataset.copy()
+    Cell2location.setup_anndata(
+        dataset_sp, labels_key="labels", batch_key="batch", categorical_covariate_keys=["labels"]
+    )
+    st_model = Cell2location(
+        dataset_sp,
+        cell_state_df=inf_aver,
+        N_cells_per_location=30,
+        detection_alpha=200,
+    )
+    # test full data training
+    st_model.train(max_epochs=1)
+    # export the estimated cell abundance (summary of the posterior distribution)
+    # full data
+    st_model.export_posterior(dataset_sp, sample_kwargs={"num_samples": 10, "batch_size": st_model.adata.n_obs})


### PR DESCRIPTION
Addresses #95 

This feature enables accounting for various covariates such as donor, age, potentially batch.
This parameter is added as a separate multiplicative parameter `y_{t,g}` with regularising prior centered at 1. E.i. exactly as technical/extra categorical covariates in the regression model.
```
\mu_{s,g} = (m_{g} \left (\sum_{f} {w_{s,f} \: g_{f,g}} \right) + s_{e,g}) y_{s} y_{t,g}
```